### PR TITLE
Keep file permissions when writing files in atomic mode

### DIFF
--- a/fsutil/__init__.py
+++ b/fsutil/__init__.py
@@ -1335,7 +1335,12 @@ def _write_file_atomic(
             file.write(content)
             file.flush()
             os.fsync(file.fileno())
-            shutil.move(file.name, path)
+            perms = None
+            if os.path.isfile(path):
+                perms = os.stat(path).st_mode
+            os.rename(file.name, path)
+            if perms:
+                os.chmod(path, perms)
     except FileNotFoundError:
         # success - the NamedTemporaryFile has not been able
         # to remove the temp file on __exit__ because the temp file

--- a/fsutil/__init__.py
+++ b/fsutil/__init__.py
@@ -1335,7 +1335,7 @@ def _write_file_atomic(
             file.write(content)
             file.flush()
             os.fsync(file.fileno())
-            os.replace(file.name, path)
+            shutil.move(file.name, path)
     except FileNotFoundError:
         # success - the NamedTemporaryFile has not been able
         # to remove the temp file on __exit__ because the temp file

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,3 +1,4 @@
+import os
 import re
 import threading
 import time
@@ -1219,10 +1220,13 @@ class fsutil_test_case(unittest.TestCase):
         fsutil.write_file(
             self.temp_path("a/b/c.txt"), content="Hello World", atomic=True
         )
+        os.chmod(path, 0o644)
         self.assertEqual(fsutil.read_file(path), "Hello World")
+        expected_permissions = os.stat(path).st_mode
         fsutil.write_file(
             self.temp_path("a/b/c.txt"), content="Hello Jupiter", atomic=True
         )
+        self.assertEqual(os.stat(path).st_mode, expected_permissions)
         self.assertEqual(fsutil.read_file(path), "Hello Jupiter")
 
     def test_write_file_with_filename_only(self):


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
Keep file permissions of the original file when using _write_file_atomic.

**Related issue**
https://github.com/fabiocaccamo/python-fsutil/issues/94

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [ ] I have added tests for the proposed changes.
- [ ] I have run the tests and there are not errors.
