### PR TITLE
fix: prevent path traversal in download_file via Content-Disposition header

### DIFF
--- a/src/fsutil/operations.py
+++ b/src/fsutil/operations.py
@@ -222,6 +222,13 @@ def download_file(
                 filename_uuid = str(uuid.uuid4())
                 filename = f"download-{filename_uuid}"
 
+        # sanitize filename to prevent path traversal attacks
+        # (e.g. a malicious server could return filename="../../.bashrc")
+        filename = os.path.basename(filename)
+        if not filename:
+            filename_uuid = str(uuid.uuid4())
+            filename = f"download-{filename_uuid}"
+
         # build filepath
         dirpath = dirpath or tempfile.gettempdir()
         dirpath = _get_path(dirpath)


### PR DESCRIPTION
## Summary

- Fixes a **path traversal vulnerability** in `download_file()` where a malicious server could return a `Content-Disposition` header with directory traversal sequences (e.g. `filename="../../.bashrc"`)
- The unsanitized filename was passed directly to `join_path()`, allowing file writes outside the intended download directory
- Fix applies `os.path.basename()` to strip directory components from the extracted filename

## Security Impact

**Severity:** High  
**Type:** CWE-22 (Path Traversal)

A malicious HTTP server can cause arbitrary file writes on the filesystem by responding with a crafted `Content-Disposition` header:

```
Content-Disposition: attachment; filename="../../.ssh/authorized_keys"
```

Any application using `fsutil.download_file()` to download from untrusted URLs is affected.

## Test plan

- [ ] Verify `download_file` with normal URLs still works
- [ ] Verify filenames with `../` sequences are sanitized to just the basename
- [ ] Verify empty basenames (e.g. `filename="../../../"`) fall back to UUID name

🤖 Generated with [Claude Code](https://claude.com/claude-code)