### PR TITLE
fix: clamp convert_size_bytes_to_string at largest unit (#184)

### DIFF
--- a/src/fsutil/converters.py
+++ b/src/fsutil/converters.py
@@ -11,7 +11,7 @@ def convert_size_bytes_to_string(size: int) -> str:
     units = SIZE_UNITS
     factor = 0
     factor_limit = len(units) - 1
-    while (size_num >= 1024) and (factor <= factor_limit):
+    while (size_num >= 1024) and (factor < factor_limit):
         size_num /= 1024
         factor += 1
     size_units = units[factor]

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -20,6 +20,21 @@ def test_convert_size_bytes_to_string(size_bytes, expected_output):
 
 
 @pytest.mark.parametrize(
+    "size_bytes, expected_output",
+    [
+        (2**80, "1.00 YB"),
+        (2**90, "1024.00 YB"),
+        (2**100, "1048576.00 YB"),
+    ],
+)
+def test_convert_size_bytes_to_string_saturates_at_largest_unit(
+    size_bytes, expected_output
+):
+    # Sizes at or above 1024 YB must clamp to the YB unit, not raise IndexError.
+    assert fsutil.convert_size_bytes_to_string(size_bytes) == expected_output
+
+
+@pytest.mark.parametrize(
     "size_string, expected_output",
     [
         ("1023 bytes", "1023 bytes"),


### PR DESCRIPTION
## Describe your changes
Fixes #184. `convert_size_bytes_to_string()` raises `IndexError` for any size of 1024 YB or more (2**90 bytes and up). Confirmed on main HEAD c98dbf6.

**Root cause:** the unit-selection loop guard is `factor <= factor_limit`. When `factor` reaches the last index (YB) and the value is still >= 1024, the loop runs once more and increments `factor` past the end of `SIZE_UNITS`, so `units[factor]` is out of range.

**Fix:** change the guard to `factor < factor_limit` so the loop stops at the largest unit and the size saturates in YB. One line changed. Sizes below 2**90 are unaffected (byte-identical output).

## Related issue
#184

## How to test
Before this PR:
```
>>> convert_size_bytes_to_string(2**90)
IndexError: list index out of range
```
After this PR:
```
>>> convert_size_bytes_to_string(2**90)
'1024.00 YB'
```
Added a parametrized regression test (2**80, 2**90, 2**100). Full converter suite: 32 passed.

## Backward compatibility
No breaking changes. Only inputs that previously raised IndexError change behavior.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.

---
Assisted-by: Claude (code generation, reviewed and tested locally)