### PR TITLE
Fix IndexError in convert_size_bytes_to_string for sizes >= 1024 YB

### DIFF
--- a/src/fsutil/converters.py
+++ b/src/fsutil/converters.py
@@ -11,7 +11,7 @@ def convert_size_bytes_to_string(size: int) -> str:
     units = SIZE_UNITS
     factor = 0
     factor_limit = len(units) - 1
-    while (size_num >= 1024) and (factor <= factor_limit):
+    while (size_num >= 1024) and (factor < factor_limit):
         size_num /= 1024
         factor += 1
     size_units = units[factor]

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -54,6 +54,9 @@ def test_convert_size_bytes_to_string_and_convert_size_string_to_bytes(
         ("1.00 MB", 1048576),
         ("1.00 GB", 1073741824),
         ("1.00 TB", 1099511627776),
+        ("1.00 YB", 2**80),
+        ("1024.00 YB", 2**90),
+        ("1048576.00 YB", 2**100),
     ],
 )
 def test_convert_size_string_to_bytes(size_string, expected_output):
@@ -72,6 +75,9 @@ def test_convert_size_string_to_bytes(size_string, expected_output):
         (1170378588, 1170378588),
         (2136746229, 2136746229),
         (1099511627776, 1099511627776),
+        (2**80, 2**80),
+        (2**90, 2**90),
+        (2**100, 2**100),
     ],
 )
 def test_convert_size_string_to_bytes_and_convert_size_bytes_to_string(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -13,6 +13,9 @@ import fsutil
         (1073741824, "1.00 GB"),
         (1879048192, "1.75 GB"),
         (1099511627776, "1.00 TB"),
+        (2**80, "1.00 YB"),
+        (2**90, "1024.00 YB"),
+        (2**100, "1048576.00 YB"),
     ],
 )
 def test_convert_size_bytes_to_string(size_bytes, expected_output):


### PR DESCRIPTION
**Describe your changes**
`convert_size_bytes_to_string()` raised `IndexError` for any size of 1024 YB or more (`2**90` bytes and up), because the unit-selection loop guard `factor <= factor_limit` let the index increment one past the last `SIZE_UNITS` entry before `units[factor]` was read. Changing the guard to `factor < factor_limit` stops at the largest unit and clamps the value to YB instead of crashing. Smaller sizes are unaffected.

**Related issue**
#184

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.
