### PR TITLE
Detect compressed tar archives during extraction

### DIFF
--- a/src/fsutil/archives.py
+++ b/src/fsutil/archives.py
@@ -114,7 +114,7 @@ def extract_tar_file(
     | None = None,
 ) -> None:
     """
-    Extract tar file at path to dest path.
+    Extract a plain or compressed tar file at path to dest path.
     If autodelete, the archive will be deleted after extraction.
     If content_paths list is defined,
     only listed items will be extracted, otherwise all.
@@ -124,7 +124,7 @@ def extract_tar_file(
     assert_file(path)
     assert_not_file(dest)
     make_dirs(dest)
-    with tarfile.TarFile(path, "r") as file:
+    with tarfile.open(path, "r:*") as file:
         if sys.version_info < (3, 12):
             file.extractall(dest, members=content_paths)
         else:

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -1,3 +1,5 @@
+import tarfile
+
 import pytest
 
 import fsutil
@@ -89,7 +91,8 @@ def test_extract_zip_file_with_autodelete(temp_path):
     assert not fsutil.is_file(zip_path)
 
 
-def test_extract_tar_file(temp_path):
+@pytest.mark.parametrize("compression", ["", "gz", "bz2", "xz"])
+def test_extract_tar_file(temp_path, compression):
     tar_path = temp_path("archive.tar")
     untar_path = temp_path("unarchive/")
     f1_path = temp_path("a/b/f1.txt")
@@ -105,7 +108,11 @@ def test_extract_tar_file(temp_path):
     fsutil.create_file(f4_path, content="hello world 4")
     fsutil.create_file(f5_path, content="hello world 5")
     fsutil.create_file(f6_path, content="hello world 6")
-    fsutil.create_tar_file(tar_path, [f1_path, f2_path, f3_path, f4_path, f5_f6_dir])
+    fsutil.create_tar_file(
+        tar_path,
+        [f1_path, f2_path, f3_path, f4_path, f5_f6_dir],
+        compression=compression,
+    )
     fsutil.extract_tar_file(tar_path, untar_path)
     assert fsutil.is_dir(untar_path)
     assert fsutil.is_file(temp_path("unarchive/f1.txt"))
@@ -117,16 +124,31 @@ def test_extract_tar_file(temp_path):
     assert fsutil.is_file(tar_path)
 
 
-def test_extract_tar_file_with_autodelete(temp_path):
+@pytest.mark.parametrize("compression", ["", "gz", "bz2", "xz"])
+def test_extract_tar_file_with_autodelete(temp_path, compression):
     tar_path = temp_path("archive.tar")
     untar_path = temp_path("unarchive/")
     path = temp_path("f1.txt")
     fsutil.create_file(path, content="hello world 1")
-    fsutil.create_tar_file(tar_path, [path])
+    fsutil.create_tar_file(tar_path, [path], compression=compression)
     fsutil.extract_tar_file(tar_path, untar_path, autodelete=True)
     assert fsutil.is_dir(untar_path)
     assert fsutil.is_file(temp_path("unarchive/f1.txt"))
     assert not fsutil.is_file(tar_path)
+
+
+@pytest.mark.parametrize("compression", ["", "gz", "bz2", "xz"])
+def test_extract_tar_file_selected_members(temp_path, compression):
+    tar_path = temp_path("archive.tar")
+    paths = [temp_path("first.txt"), temp_path("second.txt")]
+    for path in paths:
+        fsutil.create_file(path, content="hello world")
+    fsutil.create_tar_file(tar_path, paths, compression=compression)
+    with tarfile.open(tar_path) as archive:
+        members = [archive.getmember("second.txt")]
+    fsutil.extract_tar_file(tar_path, temp_path("output"), content_paths=members)
+    assert not fsutil.exists(temp_path("output/first.txt"))
+    assert fsutil.read_file(temp_path("output/second.txt")) == "hello world"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Describe your changes**

`create_tar_file(..., compression="gz"/"bz2"/"xz")` produces archives that `extract_tar_file()` currently rejects with `tarfile.ReadError`. Open archives through `tarfile.open(..., "r:*")` so extraction detects compression from the archive content.

Parameterize the existing extraction and autodelete tests over plain tar, gzip, bzip2, and xz, and cover extracting selected members for each format. The tests deliberately use a `.tar` filename for every format so detection is independent of the extension.

Validation on Windows / Python 3.12.10:

- Before the fix: 9 compressed-archive cases failed; 7 controls passed.
- Archive tests after the fix: 16 passed.
- Full suite: 175 passed, 3 platform-dependent permission tests skipped; coverage 98.36% (90% required).
- Strict mypy 2.3.1: passed for 13 source files.
- Wheel and sdist builds passed; verified the built wheel contains the corrected reader.
- Configured all-file pre-commit hooks passed, including pinned mypy 2.1.0. Ruff wrapped one overlong test call; all 16 archive tests passed again after formatting.

The other CI operating systems and Python 3.10/3.11/3.13/3.14 were not run locally. Existing extraction-filter handling and delete-after-success behavior are unchanged.

**Related issue**

No existing issue identified; this was reproduced by round-tripping archives through the public creation and extraction functions.

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.

AI disclosure: OpenAI Codex prepared the fix and tests and performed an independent agent review and verification. The self-review checkbox refers to that AI review; no human review is claimed. No third-party source code was copied.

### CI follow-up

Codacy reported B101 on the two new pytest assertions in the selected-member regression test. Add narrowly scoped `# nosec B101` annotations with a test-only explanation. The assertions and Python AST are unchanged. Bandit 1.9.4 confirms exactly those two findings disappear; all 34 pre-existing findings in that test file remain. The 16 archive tests and all configured pre-commit hooks (including Ruff and mypy) pass after the annotations.

Scrutinizer reports the same analysis/setup error on the unchanged base commit, before this PR: [base inspection](https://scrutinizer-ci.com/g/fabiocaccamo/python-fsutil/inspections/38900f87-e758-4287-84bf-277821c273d4). Its underlying log could not be accessed, so the exact service error is still unverified. The repository's full local suite passes (175 passed, 3 platform skips, 98.36% coverage); the new commit now passes all 15 GitHub Actions OS/Python matrix jobs, Codacy, and both Codecov checks (18 successful checks total). Scrutinizer still reports its pre-existing analysis/setup error.
